### PR TITLE
feat: add better support for module imports

### DIFF
--- a/src/type_resolve_helpers.ts
+++ b/src/type_resolve_helpers.ts
@@ -218,7 +218,7 @@ export function generateTree(name: string, parent: StringTreeNode | null = null)
 
             const endAt = templateIndex < 0 ? parts.length : templateIndex;
             const [name, qualifier] = parts.slice(i + 2, endAt).join('').split('~');
-            const node = new ModuleTreeNode(name, ENodeType.MODULE, parent, qualifier.replace(/\.$/, ''));
+            const node = new ModuleTreeNode(name, ENodeType.MODULE, parent, qualifier ? qualifier.replace(/\.$/, '') : '');
             if (generic)
                 generateTree(generic, node);
             if (!parent)


### PR DESCRIPTION
### Background
`tsd-jsdoc` converts `module` types to just `module`. See [#89](https://github.com/englercj/tsd-jsdoc/issues/89)

### What this PR fixes
- Introduces a new Module type
- Resolves module to import statements